### PR TITLE
Tracing kyo high

### DIFF
--- a/kyo-high.scala
+++ b/kyo-high.scala
@@ -6,27 +6,33 @@ import kyo.*
 class KyoScraperHighLevel(
     fetch: Fetch[Kyo],
     store: Store[Kyo],
+    tracing: TracingKyo,
     root: Uri,
     selector: Option[String],
     maxDepth: Int,
     parallelism: Int = 8
 ):
   def start: Unit < (Async & Abort[Throwable]) =
-    Scope.run:
-      for
-        queue <- Channel.init[Scrape](Int.MaxValue)
-        inFlight <- AtomicInt.init(0)
-        visited <- AtomicRef.init(Set.empty[Uri])
-        _ <- inFlight.incrementAndGet
-        _ <- queue.put(Scrape(root, 0))
-        _ <- Async.fill(parallelism, parallelism)(worker(queue, inFlight, visited))
-      yield ()
+    tracing.root("start"):
+      tracing.span("coordinator (pre channel scope)"):
+        Scope.run:
+          tracing.span("coordinator (in channel scope)"):
+            for
+              queue <- Channel.init[Scrape](Int.MaxValue)
+              inFlight <- AtomicInt.init(0)
+              visited <- AtomicRef.init(Set.empty[Uri])
+              _ <- inFlight.incrementAndGet
+              _ <- queue.put(Scrape(root, 0))
+              _ <-
+                tracing.span("coordinator (pre loop scope)"):
+                  Async.fill(parallelism, parallelism)(worker(queue, inFlight, visited))
+            yield ()
 
   private def worker(
       queue: Channel[Scrape],
       inFlight: AtomicInt,
       visited: AtomicRef[Set[Uri]]
-  ): Unit < (Async & Abort[Throwable]) =
+  )(using Trace): Unit < (Async & Abort[Throwable]) =
     Loop.foreach:
       Abort.recover[Closed](_ => Loop.done):
         queue.take.map:
@@ -45,11 +51,12 @@ class KyoScraperHighLevel(
                 if currentInFlight > 0 then Loop.continue
                 else queue.closeAwaitEmpty.andThen(Loop.done)
 
-  def crawl(uri: Uri, depth: Int, inFlight: AtomicInt, queue: Channel[Scrape]): Unit < (Async & Abort[Throwable]) =
-    for
-      content <- fetch.fetch(uri)
-      (links, markdown) <- Abort.get(MdConverter.convertAndExtractLinks(content, uri, selector))
-      pushFrontier = inFlight.addAndGet(links.size).andThen(queue.putBatch(links.map(Scrape(_, depth + 1))))
-      persist = store.store(Names.toFilename(uri, root), markdown)
-      _ <- Async.zip(pushFrontier, persist)
-    yield ()
+  def crawl(uri: Uri, depth: Int, inFlight: AtomicInt, queue: Channel[Scrape])(using Trace): Unit < (Async & Abort[Throwable]) =
+    tracing.span(s"crawl(${uri.pathToString})"):
+      for
+        content <- fetch.fetch(uri)
+        (links, markdown) <- Abort.get(MdConverter.convertAndExtractLinks(content, uri, selector))
+        pushFrontier = inFlight.addAndGet(links.size).andThen(queue.putBatch(links.map(Scrape(_, depth + 1))))
+        persist = store.store(Names.toFilename(uri, root), markdown)
+        _ <- Async.zip(pushFrontier, persist)
+      yield ()

--- a/main.scala
+++ b/main.scala
@@ -106,9 +106,15 @@ def run(variant: String, root: String, selector: Option[String]): Unit =
 
       val fetch = Fetch.kyo
       val store = Store.kyo(outputDir)
-      val scraper = KyoScraperHighLevel(fetch, store, rootUri, selector, maxDepth = 20)
+      val tracingScope = Tracing.kyo("kyo-high-debug")
 
-      KyoApp.Unsafe.runAndBlock(Duration.Infinity)(scraper.start).getOrThrow
+      KyoApp.Unsafe
+        .runAndBlock(Duration.Infinity) {
+          Scope.run:
+            tracingScope.map: tracing =>
+              KyoScraperHighLevel(fetch, store, tracing, rootUri, selector, maxDepth = 20).start
+        }
+        .getOrThrow
 
     case "ox" =>
       val fetch = Fetch.sync

--- a/tracing.scala
+++ b/tracing.scala
@@ -137,7 +137,7 @@ object Tracing:
           start <- KyoClock.now
           _ <- KyoScope.ensure(
             KyoClock.now.map { end =>
-          spans.add(SpanData(rootTrace.id, None, n, None, start.toJava, end.toJava))
+              spans.add(SpanData(rootTrace.id, None, n, None, start.toJava, end.toJava))
             }
           )
           res <- body(using rootTrace)

--- a/tracing.scala
+++ b/tracing.scala
@@ -109,7 +109,7 @@ object Tracing:
       yield res
 
   class KyoTracing(spans: ConcurrentLinkedQueue[SpanData]) extends TracingKyo:
-    def span1[A, S](n: String)(body: Trace ?=> A < S)(using p: Trace): A < (Async & S) =
+    def span[A, S](n: String)(body: Trace ?=> A < S)(using p: Trace): A < (Async & S) =
       val childTrace = Trace(p.uri)
       KyoScope.run:
         for
@@ -120,7 +120,7 @@ object Tracing:
           res <- body(using childTrace)
         yield res
 
-    def span[A, S](n: String)(body: Trace ?=> A < S)(using p: Trace): A < (Async & S) =
+    def spanNoScope[A, S](n: String)(body: Trace ?=> A < S)(using p: Trace): A < (Async & S) =
       val childTrace = Trace(p.uri)
       for
         start <- KyoClock.now
@@ -130,7 +130,7 @@ object Tracing:
         }
       yield res
 
-    def root1[A, S](n: String)(body: Trace ?=> A < S): A < (Async & S) =
+    def root[A, S](n: String)(body: Trace ?=> A < S): A < (Async & S) =
       val rootTrace = Trace(None)
       KyoScope.run:
         for
@@ -143,7 +143,7 @@ object Tracing:
           res <- body(using rootTrace)
         yield res
 
-    def root[A, S](n: String)(body: Trace ?=> A < S): A < (Async & S) =
+    def rootNoScope[A, S](n: String)(body: Trace ?=> A < S): A < (Async & S) =
       val rootTrace = Trace(None)
       for
         start <- KyoClock.now


### PR DESCRIPTION
kyo with tracing scope:
<img width="3840" height="4888" alt="before" src="https://github.com/user-attachments/assets/5e8100bf-4391-4d71-99bf-5a6f3682ed76" />

kyo without the tracing scope:
<img width="3840" height="4936" alt="after" src="https://github.com/user-attachments/assets/4bfadbf1-e86f-4769-89d0-a87a50ac30b8" />

kyo-high with tracing scope:
<img width="3840" height="4936" alt="127 0 0 1_9999_ (2)" src="https://github.com/user-attachments/assets/a9852070-2d12-4c69-bd4f-0ddb16563074" />

I do not think that there is enough evidence to conclude that Kyo scope is fully to blame for the different here. Yes it makes a difference with kyo low level but it is unclear why. The same scopes in kyo-high cause no problem.